### PR TITLE
Migrate from STPyV8 to QuickJS as JavaScript engine

### DIFF
--- a/devlog.md
+++ b/devlog.md
@@ -1,0 +1,87 @@
+# Development Log
+
+## 2026-01-01: QuickJS Migration
+
+### Goal
+Replace STPyV8 (V8 bindings) with QuickJS as the JavaScript engine for CyberChef execution.
+
+### Why QuickJS?
+- **STPyV8 pain points**: Large binary (~50MB), complex build requirements, platform-specific issues
+- **QuickJS benefits**: ~300KB, pure Python wheel, ES2023 support, memory/time limits
+
+### Key Decisions
+
+1. **Used `quickjs` PyPI package** (v1.19.4) - thin wrapper by Petter Strandmark
+   - Alternative `pyquickjs` exists but `quickjs` has better docs and is more maintained
+
+2. **Rewrote `cyberchef.py` to use Context API**
+   - QuickJS returns a Context, not an object with methods like STPyV8
+   - All JS execution goes through `ctx.eval()` with JSON serialization for data passing
+   - Dish objects serialized to/from JSON rather than crossing Python/JS boundary directly
+
+3. **Made Qt imports optional** in `__init__.py`
+   - Enables headless usage (tests, CLI) without Qt dependencies
+   - Qt widgets only imported if available
+
+4. **Standardized on `bake()` API**
+   - Old tests used direct method calls (`chef.fromBase64()`)
+   - New approach: everything goes through `bake(input, recipe)`
+
+### Technical Details
+
+```python
+# Old (STPyV8):
+ctx = STPyV8.JSContext()
+ctx.enter()
+chef = ctx.eval("module.exports")
+result = chef.fromBase64(input)  # Direct method call
+
+# New (QuickJS):
+ctx = quickjs.Context()
+ctx.eval(cyberchef_code)
+result_json = ctx.eval(f"""
+    const result = _cyberchef.bake(dish, recipe);
+    JSON.stringify(result);
+""")
+result = json.loads(result_json)
+```
+
+### Test Results
+- **132 passed, 5 failed (96.4%)**
+- Created `test_operations_comprehensive.py` with 116 new tests
+
+### Working Operations
+All major categories work:
+- Encodings (Base64, Hex, URL, HTML, Binary, Octal)
+- Hashing (MD5, SHA family, BLAKE2, CRC, HMAC)
+- String manipulation (Reverse, Case, Split, Sort)
+- Logic operations (XOR, AND, OR, bit shifts)
+- Classical ciphers (ROT13, Vigenère, Atbash)
+- Network parsing (IP, URL extraction)
+- JSON/XML formatting
+
+### Known Issues
+
+1. **Compression ops fail** (Zlib, Gzip) - `out-of-bound numeric index` error
+   - Likely typed array handling issue in QuickJS
+   - Workaround: Use Python's `zlib` module instead
+
+2. **AES/RC4 roundtrip** - argument format mismatch
+   - Encryption works, decryption needs investigation
+   - Args structure differs from web UI
+
+3. **Some conversions** (distance, mass) - wrong arg names
+   - Need to check operation_schema.json for correct parameter names
+
+### Files Changed
+- `pyproject.toml`: `stpyv8` → `quickjs`
+- `ida_cyberchef/cyberchef.py`: Complete rewrite
+- `ida_cyberchef/__init__.py`: Optional Qt imports
+- `tests/test_cyberchef.py`: Updated to use `bake()` API
+- `tests/test_operations_comprehensive.py`: New comprehensive test suite
+
+### Future Work
+- [ ] Fix compression operations (may need custom polyfill)
+- [ ] Debug AES/RC4 argument handling
+- [ ] Add more edge case tests
+- [ ] Performance comparison vs STPyV8

--- a/ida_cyberchef/__init__.py
+++ b/ida_cyberchef/__init__.py
@@ -4,7 +4,15 @@ This package provides CyberChef data transformation capabilities for IDA Pro
 through both a Qt widget interface and a programmatic API.
 """
 
-# Main widget
+# Core CyberChef API (always available)
+from ida_cyberchef.cyberchef import (
+    DishType,
+    bake,
+    get_chef,
+    load_cyberchef,
+    plate,
+)
+
 # Input parsing
 from ida_cyberchef.core.input_parser import InputFormat
 
@@ -14,36 +22,14 @@ from ida_cyberchef.core.operation_registry import OperationRegistry
 # Recipe data structures
 from ida_cyberchef.core.recipe_models import OperationStep, RecipeDefinition
 
-# Core CyberChef API
-from ida_cyberchef.cyberchef import (
-    DishType,
-    bake,
-    get_chef,
-    load_cyberchef,
-    plate,
-)
-from ida_cyberchef.cyberchef_widget import CyberChefWidget
-
-# Qt models
-from ida_cyberchef.qt_models.execution_model import ExecutionModel
-from ida_cyberchef.qt_models.input_model import InputModel, InputSource
-from ida_cyberchef.qt_models.recipe_model import RecipeModel
-
 __all__ = [
-    # Main widget
-    "CyberChefWidget",
     # Core CyberChef API
     "bake",
     "get_chef",
     "load_cyberchef",
     "plate",
     "DishType",
-    # Qt models
-    "InputModel",
-    "RecipeModel",
-    "ExecutionModel",
     # Enums
-    "InputSource",
     "InputFormat",
     # Recipe structures
     "RecipeDefinition",
@@ -51,3 +37,21 @@ __all__ = [
     # Registry
     "OperationRegistry",
 ]
+
+# Qt-dependent imports (optional - only if Qt is available)
+try:
+    from ida_cyberchef.cyberchef_widget import CyberChefWidget
+    from ida_cyberchef.qt_models.execution_model import ExecutionModel
+    from ida_cyberchef.qt_models.input_model import InputModel, InputSource
+    from ida_cyberchef.qt_models.recipe_model import RecipeModel
+
+    __all__.extend([
+        "CyberChefWidget",
+        "InputModel",
+        "RecipeModel",
+        "ExecutionModel",
+        "InputSource",
+    ])
+except ImportError:
+    # Qt not available (headless environment)
+    pass

--- a/ida_cyberchef/runtime/__init__.py
+++ b/ida_cyberchef/runtime/__init__.py
@@ -1,0 +1,151 @@
+"""JavaScript runtime abstraction for CyberChef.
+
+This module provides a unified interface for different JavaScript engines:
+- QuickJS: Small, embeddable, always available as fallback
+- STPyV8: Google V8 bindings, best compatibility
+- PythonMonkey: Mozilla SpiderMonkey bindings
+
+Usage:
+    from ida_cyberchef.runtime import get_runtime, JSRuntime
+
+    runtime = get_runtime()  # Auto-detect best available
+    runtime.load("/path/to/CyberChef.js")
+    result = runtime.bake(input_dish, recipe)
+"""
+
+from typing import TYPE_CHECKING
+
+from .base import JSRuntime
+
+if TYPE_CHECKING:
+    pass
+
+__all__ = ["JSRuntime", "get_runtime", "get_available_runtimes", "RuntimeNotAvailableError"]
+
+
+class RuntimeNotAvailableError(ImportError):
+    """Raised when no JavaScript runtime is available."""
+
+    pass
+
+
+def _try_import_quickjs() -> bool:
+    """Check if QuickJS is available."""
+    try:
+        import quickjs  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _try_import_stpyv8() -> bool:
+    """Check if STPyV8 is available."""
+    try:
+        import STPyV8  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _try_import_pythonmonkey() -> bool:
+    """Check if PythonMonkey is available."""
+    try:
+        import pythonmonkey  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def get_available_runtimes() -> list[str]:
+    """Get list of available runtime names.
+
+    Returns:
+        List of available runtime names in order of preference
+    """
+    available = []
+
+    # Order of preference: STPyV8 > PythonMonkey > QuickJS
+    # STPyV8 has best compatibility (V8 engine, zlib works)
+    # PythonMonkey is SpiderMonkey-based, good compatibility
+    # QuickJS always available as fallback but needs compression workarounds
+
+    if _try_import_stpyv8():
+        available.append("stpyv8")
+    if _try_import_pythonmonkey():
+        available.append("pythonmonkey")
+    if _try_import_quickjs():
+        available.append("quickjs")
+
+    return available
+
+
+def get_runtime(preferred: str | None = None) -> JSRuntime:
+    """Get JavaScript runtime instance.
+
+    Args:
+        preferred: Preferred runtime name ('quickjs', 'stpyv8', 'pythonmonkey').
+                  If None, auto-selects best available.
+
+    Returns:
+        JSRuntime instance
+
+    Raises:
+        RuntimeNotAvailableError: If no runtime is available
+        ValueError: If preferred runtime is not recognized
+    """
+    available = get_available_runtimes()
+
+    if not available:
+        raise RuntimeNotAvailableError(
+            "No JavaScript runtime available. Install one of: "
+            "quickjs, stpyv8, pythonmonkey"
+        )
+
+    # If preferred is specified, try to use it
+    if preferred is not None:
+        preferred = preferred.lower()
+        valid_runtimes = {"quickjs", "stpyv8", "pythonmonkey"}
+
+        if preferred not in valid_runtimes:
+            raise ValueError(
+                f"Unknown runtime '{preferred}'. Valid options: {valid_runtimes}"
+            )
+
+        if preferred not in available:
+            raise RuntimeNotAvailableError(
+                f"Requested runtime '{preferred}' is not available. "
+                f"Available runtimes: {available}"
+            )
+
+        return _create_runtime(preferred)
+
+    # Auto-select best available (first in preference order)
+    return _create_runtime(available[0])
+
+
+def _create_runtime(name: str) -> JSRuntime:
+    """Create runtime instance by name.
+
+    Args:
+        name: Runtime name (lowercase)
+
+    Returns:
+        JSRuntime instance
+    """
+    if name == "quickjs":
+        from .quickjs_runtime import QuickJSRuntime
+
+        return QuickJSRuntime()
+    elif name == "stpyv8":
+        from .stpyv8_runtime import STPyV8Runtime
+
+        return STPyV8Runtime()
+    elif name == "pythonmonkey":
+        from .pythonmonkey_runtime import PythonMonkeyRuntime
+
+        return PythonMonkeyRuntime()
+    else:
+        raise ValueError(f"Unknown runtime: {name}")

--- a/ida_cyberchef/runtime/base.py
+++ b/ida_cyberchef/runtime/base.py
@@ -1,0 +1,66 @@
+"""Abstract base class for JavaScript runtime adapters.
+
+Each runtime (QuickJS, STPyV8, PythonMonkey) implements this interface
+to provide CyberChef execution capabilities.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class JSRuntime(ABC):
+    """Abstract base class for JavaScript runtimes.
+
+    Implementations must provide:
+    - Loading CyberChef bundle
+    - Executing bake() with input dish and recipe
+    - Converting results back to Python types
+    """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Human-readable name of this runtime."""
+        ...
+
+    @property
+    def needs_compression_fallback(self) -> bool:
+        """Whether this runtime needs Python fallbacks for compression.
+
+        QuickJS has stricter typed array bounds checking that breaks
+        CyberChef's zlib.js. STPyV8 (V8) handles it fine.
+
+        Returns:
+            True if compression operations should use Python stdlib
+        """
+        return False
+
+    @abstractmethod
+    def load(self, cyberchef_path: str) -> None:
+        """Load CyberChef bundle into the runtime.
+
+        Args:
+            cyberchef_path: Path to CyberChef.js bundle file
+        """
+        ...
+
+    @abstractmethod
+    def bake(self, input_dish: dict[str, Any], recipe: list) -> dict[str, Any]:
+        """Execute CyberChef bake operation.
+
+        Args:
+            input_dish: Input data as Dish dict with 'value' and 'type' keys
+            recipe: List of operations (strings or dicts with 'op' and 'args')
+
+        Returns:
+            Result Dish dict with 'value' and 'type' keys
+        """
+        ...
+
+    def setup_environment(self) -> None:
+        """Set up minimal browser/Node environment for CyberChef.
+
+        Override if runtime needs custom setup. Default implementation
+        provides common polyfills via eval().
+        """
+        pass

--- a/ida_cyberchef/runtime/pythonmonkey_runtime.py
+++ b/ida_cyberchef/runtime/pythonmonkey_runtime.py
@@ -1,0 +1,174 @@
+"""PythonMonkey runtime adapter for CyberChef.
+
+PythonMonkey embeds Mozilla's SpiderMonkey JavaScript engine into Python.
+It provides seamless interop between Python and JavaScript via proxy objects.
+
+Advantages:
+- SpiderMonkey engine (same as Firefox)
+- Direct proxy object interop without JSON serialization
+- WebAssembly support
+- Active development
+
+Note:
+- Compression compatibility needs testing; may or may not need fallbacks
+"""
+
+import json
+from typing import Any
+
+from .base import JSRuntime
+
+
+class PythonMonkeyRuntime(JSRuntime):
+    """PythonMonkey (SpiderMonkey) JavaScript runtime."""
+
+    def __init__(self):
+        self._pm = None
+        self._cyberchef = None
+        self._needs_compression_fallback = None  # Determined at runtime
+
+    @property
+    def name(self) -> str:
+        return "PythonMonkey"
+
+    @property
+    def needs_compression_fallback(self) -> bool:
+        # Test compression on first use if not yet determined
+        if self._needs_compression_fallback is None:
+            self._needs_compression_fallback = self._test_compression()
+        return self._needs_compression_fallback
+
+    def _test_compression(self) -> bool:
+        """Test if zlib.js works in this runtime."""
+        if self._cyberchef is None:
+            # Can't test yet, assume it needs fallback to be safe
+            return True
+
+        try:
+            # Try a simple compression operation
+            test_dish = {"value": list(b"test"), "type": 4}  # ARRAY_BUFFER
+            self.bake(test_dish, ["Zlib Deflate"])
+            return False  # Compression works!
+        except Exception:
+            return True  # Needs fallback
+
+    def load(self, cyberchef_path: str) -> None:
+        """Load CyberChef into SpiderMonkey context."""
+        import pythonmonkey as pm
+
+        self._pm = pm
+
+        # Setup global environment
+        self.setup_environment()
+
+        # Load CyberChef via eval
+        # PythonMonkey uses eval() directly on the module
+        with open(cyberchef_path, "rb") as f:
+            cyberchef_code = f.read().decode("utf-8")
+
+        # Wrap in module pattern and execute
+        wrapper = f"""
+        (function() {{
+            const module = {{ exports: {{}} }};
+            {cyberchef_code}
+            return module.exports;
+        }})()
+        """
+        self._cyberchef = pm.eval(wrapper)
+
+    def setup_environment(self) -> None:
+        """Set up browser/Node polyfills for CyberChef."""
+        self._pm.eval("""
+        globalThis.global = globalThis;
+        globalThis.window = globalThis;
+        globalThis.self = globalThis;
+        globalThis.document = {};
+
+        // Minimal process polyfill
+        globalThis.process = {
+            platform: 'linux',
+            env: {},
+            cwd: () => '/',
+            version: 'v18.0.0',
+            versions: {node: 'v18.0.0'},
+            nextTick: (fn) => fn()
+        };
+
+        // Timer polyfills
+        if (typeof setTimeout === 'undefined') {
+            globalThis.setTimeout = function(fn, ms) { fn(); return 0; };
+        }
+        if (typeof setInterval === 'undefined') {
+            globalThis.setInterval = function(fn, ms) { return 0; };
+        }
+        globalThis.clearTimeout = globalThis.clearTimeout || function(id) {};
+        globalThis.clearInterval = globalThis.clearInterval || function(id) {};
+        """)
+
+    def bake(self, input_dish: dict[str, Any], recipe: list) -> dict[str, Any]:
+        """Execute CyberChef bake with SpiderMonkey proxy objects."""
+        if self._cyberchef is None:
+            raise RuntimeError("PythonMonkey runtime not loaded. Call load() first.")
+
+        # DishType constants
+        ARRAY_BUFFER = 4
+        BYTE_ARRAY = 0
+        STRING = 1
+
+        dish_type = input_dish.get("type", STRING)
+        dish_value = input_dish.get("value")
+
+        # Create JS Dish object
+        if dish_type in (ARRAY_BUFFER, BYTE_ARRAY) and isinstance(dish_value, list):
+            # Create Uint8Array and Dish
+            byte_json = json.dumps(dish_value)
+            recipe_json = json.dumps(recipe)
+
+            result = self._pm.eval(f"""
+            (function(cyberchef) {{
+                const byteArray = {byte_json};
+                const uint8 = new Uint8Array(byteArray);
+                const dish = new cyberchef.Dish(uint8.buffer, cyberchef.Dish.ARRAY_BUFFER);
+                const recipe = {recipe_json};
+                return cyberchef.bake(dish, recipe);
+            }})
+            """)(self._cyberchef)
+        else:
+            # String input
+            recipe_json = json.dumps(recipe)
+            value_json = json.dumps(dish_value)
+
+            result = self._pm.eval(f"""
+            (function(cyberchef) {{
+                const dish = new cyberchef.Dish({value_json}, cyberchef.Dish.STRING);
+                const recipe = {recipe_json};
+                return cyberchef.bake(dish, recipe);
+            }})
+            """)(self._cyberchef)
+
+        # Convert result to Python dict
+        return self._convert_result(result)
+
+    def _convert_result(self, result) -> dict[str, Any]:
+        """Convert SpiderMonkey Dish proxy to Python dict."""
+        result_type = int(result.type)
+        result_value = result.value
+
+        # DishType constants
+        ARRAY_BUFFER = 4
+        BYTE_ARRAY = 0
+
+        if result_type in (ARRAY_BUFFER, BYTE_ARRAY):
+            # Convert typed array to Python list
+            if hasattr(result_value, "__iter__"):
+                try:
+                    result_value = list(result_value)
+                except Exception:
+                    # Fallback: convert via JSON
+                    result_value = list(self._pm.eval("""
+                    (function(v) { return Array.from(new Uint8Array(v)); })
+                    """)(result_value))
+            elif isinstance(result_value, (bytes, bytearray)):
+                result_value = list(result_value)
+
+        return {"value": result_value, "type": result_type}

--- a/ida_cyberchef/runtime/pythonmonkey_runtime.py
+++ b/ida_cyberchef/runtime/pythonmonkey_runtime.py
@@ -84,6 +84,13 @@ class PythonMonkeyRuntime(JSRuntime):
         globalThis.self = globalThis;
         globalThis.document = {};
 
+        // CyberChef app polyfill for window.app.options
+        globalThis.window.app = {
+            options: {
+                attemptHighlight: false
+            }
+        };
+
         // Minimal process polyfill
         globalThis.process = {
             platform: 'linux',

--- a/ida_cyberchef/runtime/quickjs_runtime.py
+++ b/ida_cyberchef/runtime/quickjs_runtime.py
@@ -1,0 +1,185 @@
+"""QuickJS runtime adapter for CyberChef.
+
+QuickJS is a small, embeddable JavaScript engine with ES2023 support.
+It requires JSON serialization for data passing between Python and JS.
+
+Limitations:
+- Stricter typed array bounds checking breaks CyberChef's zlib.js
+- Compression operations need Python stdlib fallbacks
+"""
+
+import json
+from typing import Any
+
+from .base import JSRuntime
+
+
+class QuickJSRuntime(JSRuntime):
+    """QuickJS-based JavaScript runtime."""
+
+    def __init__(self):
+        self._ctx = None
+
+    @property
+    def name(self) -> str:
+        return "QuickJS"
+
+    @property
+    def needs_compression_fallback(self) -> bool:
+        # QuickJS typed array bounds checking breaks zlib.js Huffman encoding
+        return True
+
+    def load(self, cyberchef_path: str) -> None:
+        """Load CyberChef into QuickJS context."""
+        import quickjs
+
+        self._ctx = quickjs.Context()
+
+        # Set generous limits for CyberChef operations
+        self._ctx.set_memory_limit(256 * 1024 * 1024)  # 256MB
+        self._ctx.set_time_limit(-1)  # No time limit
+
+        self.setup_environment()
+
+        # Setup CommonJS module wrapper
+        self._ctx.eval("const module = { exports: {} };")
+
+        # Load CyberChef
+        with open(cyberchef_path, "rb") as f:
+            cyberchef_code = f.read().decode("utf-8")
+        self._ctx.eval(cyberchef_code)
+
+        # Store reference for bake operations
+        self._ctx.eval("globalThis._cyberchef = module.exports;")
+
+    def setup_environment(self) -> None:
+        """Set up browser/Node polyfills for CyberChef."""
+        self._ctx.eval("""
+        globalThis.global = globalThis;
+        globalThis.window = globalThis;
+        globalThis.self = globalThis;
+        globalThis.document = {};
+
+        // Minimal process polyfill
+        globalThis.process = {
+            platform: 'linux',
+            env: {},
+            cwd: () => '/',
+            version: 'v18.0.0',
+            versions: {node: 'v18.0.0'},
+            nextTick: (fn) => fn()
+        };
+
+        // TextEncoder/TextDecoder polyfill
+        if (typeof TextEncoder === 'undefined') {
+            globalThis.TextEncoder = class TextEncoder {
+                encode(str) {
+                    const utf8 = unescape(encodeURIComponent(str));
+                    const result = new Uint8Array(utf8.length);
+                    for (let i = 0; i < utf8.length; i++) {
+                        result[i] = utf8.charCodeAt(i);
+                    }
+                    return result;
+                }
+            };
+        }
+
+        if (typeof TextDecoder === 'undefined') {
+            globalThis.TextDecoder = class TextDecoder {
+                decode(bytes) {
+                    if (bytes instanceof ArrayBuffer) {
+                        bytes = new Uint8Array(bytes);
+                    }
+                    const utf8 = Array.from(bytes).map(b => String.fromCharCode(b)).join('');
+                    try {
+                        return decodeURIComponent(escape(utf8));
+                    } catch (e) {
+                        return utf8;
+                    }
+                }
+            };
+        }
+
+        // Crypto API polyfill
+        if (typeof crypto === 'undefined') {
+            globalThis.crypto = {};
+        }
+        if (!globalThis.crypto.getRandomValues) {
+            globalThis.crypto.getRandomValues = function(array) {
+                for (let i = 0; i < array.length; i++) {
+                    array[i] = Math.floor(Math.random() * 256);
+                }
+                return array;
+            };
+        }
+
+        // Timer polyfills
+        globalThis.setTimeout = function(fn, ms) { fn(); return 0; };
+        globalThis.setInterval = function(fn, ms) { return 0; };
+        globalThis.clearTimeout = function(id) {};
+        globalThis.clearInterval = function(id) {};
+
+        // Console polyfill
+        if (typeof console === 'undefined') {
+            globalThis.console = {
+                log: function() {},
+                warn: function() {},
+                error: function() {},
+                info: function() {},
+                debug: function() {}
+            };
+        }
+        """)
+
+    def bake(self, input_dish: dict[str, Any], recipe: list) -> dict[str, Any]:
+        """Execute CyberChef bake via JSON serialization."""
+        if self._ctx is None:
+            raise RuntimeError("QuickJS runtime not loaded. Call load() first.")
+
+        # DishType constants
+        ARRAY_BUFFER = 4
+        BYTE_ARRAY = 0
+        STRING = 1
+
+        input_json = json.dumps(input_dish)
+        recipe_json = json.dumps(recipe)
+
+        result_json = self._ctx.eval(f"""
+        (function() {{
+            const inputDish = {input_json};
+            const recipe = {recipe_json};
+
+            // Create proper Dish object
+            let dish;
+            if (inputDish.type === {ARRAY_BUFFER} || inputDish.type === {BYTE_ARRAY}) {{
+                const uint8 = new Uint8Array(inputDish.value);
+                dish = new _cyberchef.Dish(uint8.buffer, _cyberchef.Dish.ARRAY_BUFFER);
+            }} else if (inputDish.type === {STRING}) {{
+                dish = new _cyberchef.Dish(inputDish.value, _cyberchef.Dish.STRING);
+            }} else {{
+                dish = new _cyberchef.Dish(inputDish.value, inputDish.type);
+            }}
+
+            // Execute bake
+            const result = _cyberchef.bake(dish, recipe);
+
+            // Convert result to JSON-serializable format
+            const resultType = result.type;
+            let resultValue = result.value;
+
+            if (resultType === _cyberchef.Dish.ARRAY_BUFFER || resultType === _cyberchef.Dish.BYTE_ARRAY) {{
+                if (resultValue instanceof ArrayBuffer) {{
+                    resultValue = Array.from(new Uint8Array(resultValue));
+                }} else if (resultValue instanceof Uint8Array) {{
+                    resultValue = Array.from(resultValue);
+                }}
+            }}
+
+            return JSON.stringify({{
+                value: resultValue,
+                type: resultType
+            }});
+        }})()
+        """)
+
+        return json.loads(result_json)

--- a/ida_cyberchef/runtime/quickjs_runtime.py
+++ b/ida_cyberchef/runtime/quickjs_runtime.py
@@ -60,6 +60,15 @@ class QuickJSRuntime(JSRuntime):
         globalThis.self = globalThis;
         globalThis.document = {};
 
+        // CyberChef app polyfill for window.app.options
+        // The 'From Charcode' and similar operations check window.app.options.attemptHighlight
+        // to control syntax highlighting behavior. In non-browser environments, we disable it.
+        globalThis.window.app = {
+            options: {
+                attemptHighlight: false
+            }
+        };
+
         // Minimal process polyfill
         globalThis.process = {
             platform: 'linux',

--- a/ida_cyberchef/runtime/stpyv8_runtime.py
+++ b/ida_cyberchef/runtime/stpyv8_runtime.py
@@ -1,0 +1,184 @@
+"""STPyV8 runtime adapter for CyberChef.
+
+STPyV8 provides Python bindings to Google's V8 JavaScript engine.
+It offers direct object interop between Python and JavaScript.
+
+Advantages:
+- Full V8 compatibility (same engine as Chrome/Node.js)
+- Direct Python/JS object interop without JSON serialization
+- CyberChef's zlib.js works correctly
+
+Disadvantages:
+- Large binary size (~50MB)
+- Complex build requirements
+- Platform-specific issues
+"""
+
+import json
+from typing import Any
+
+from .base import JSRuntime
+
+
+class STPyV8Runtime(JSRuntime):
+    """STPyV8 (V8) JavaScript runtime."""
+
+    def __init__(self):
+        self._ctx = None
+        self._chef = None
+
+    @property
+    def name(self) -> str:
+        return "STPyV8"
+
+    @property
+    def needs_compression_fallback(self) -> bool:
+        # V8 handles zlib.js correctly
+        return False
+
+    def load(self, cyberchef_path: str) -> None:
+        """Load CyberChef into V8 context."""
+        import STPyV8
+
+        self._ctx = STPyV8.JSContext()
+        self._ctx.enter()
+
+        self.setup_environment()
+
+        # Setup CommonJS module wrapper
+        self._ctx.eval("const module = { exports: {} };")
+
+        # Load CyberChef
+        with open(cyberchef_path, "rb") as f:
+            self._ctx.eval(f.read().decode("utf-8"))
+
+        # Store reference to exports
+        self._chef = self._ctx.eval("module.exports")
+
+    def setup_environment(self) -> None:
+        """Set up browser/Node polyfills for CyberChef."""
+        self._ctx.eval("""
+        globalThis.global = globalThis;
+        globalThis.window = globalThis;
+        globalThis.self = globalThis;
+        globalThis.document = {};
+
+        // Minimal process polyfill
+        globalThis.process = {
+            platform: 'linux',
+            env: {},
+            cwd: () => '/',
+            version: 'v18.0.0',
+            versions: {node: 'v18.0.0'},
+            nextTick: (fn) => setTimeout(fn, 0)
+        };
+
+        // TextEncoder/TextDecoder polyfill
+        if (typeof TextEncoder === 'undefined') {
+            globalThis.TextEncoder = class TextEncoder {
+                encode(str) {
+                    const utf8 = unescape(encodeURIComponent(str));
+                    const result = new Uint8Array(utf8.length);
+                    for (let i = 0; i < utf8.length; i++) {
+                        result[i] = utf8.charCodeAt(i);
+                    }
+                    return result;
+                }
+            };
+        }
+
+        if (typeof TextDecoder === 'undefined') {
+            globalThis.TextDecoder = class TextDecoder {
+                decode(bytes) {
+                    const utf8 = Array.from(bytes).map(b => String.fromCharCode(b)).join('');
+                    return decodeURIComponent(escape(utf8));
+                }
+            };
+        }
+
+        // Crypto API polyfill
+        if (typeof crypto === 'undefined') {
+            globalThis.crypto = {};
+        }
+        if (!globalThis.crypto.getRandomValues) {
+            globalThis.crypto.getRandomValues = function(array) {
+                for (let i = 0; i < array.length; i++) {
+                    array[i] = Math.floor(Math.random() * 256);
+                }
+                return array;
+            };
+        }
+
+        // Timer polyfills
+        globalThis.setTimeout = function(fn, ms) { fn(); return 0; };
+        globalThis.setInterval = function(fn, ms) { return 0; };
+        globalThis.clearTimeout = function(id) {};
+        globalThis.clearInterval = function(id) {};
+        """)
+
+    def bake(self, input_dish: dict[str, Any], recipe: list) -> dict[str, Any]:
+        """Execute CyberChef bake with direct V8 object interop."""
+        import STPyV8
+
+        if self._ctx is None:
+            raise RuntimeError("STPyV8 runtime not loaded. Call load() first.")
+
+        # DishType constants
+        ARRAY_BUFFER = 4
+        BYTE_ARRAY = 0
+
+        # For bytes input, create proper Dish via JS
+        dish_type = input_dish.get("type", 1)
+        dish_value = input_dish.get("value")
+
+        if dish_type in (ARRAY_BUFFER, BYTE_ARRAY) and isinstance(dish_value, list):
+            # Create Dish from byte array via JS
+            byte_json = json.dumps(dish_value)
+            js_dish = self._ctx.eval(f"""
+            (function() {{
+                const byteArray = {byte_json};
+                const uint8 = new Uint8Array(byteArray);
+                return new module.exports.Dish(uint8.buffer, module.exports.Dish.ARRAY_BUFFER);
+            }})()
+            """)
+        else:
+            # String or other input - pass directly
+            js_dish = dish_value
+
+        # Execute bake
+        recipe_json = json.dumps(recipe)
+        self._ctx.locals.input_dish = js_dish
+        result = self._ctx.eval(f"""
+        (function() {{
+            const recipe = {recipe_json};
+            return module.exports.bake(input_dish, recipe);
+        }})()
+        """)
+
+        # Convert result to Python dict
+        return self._convert_result(result)
+
+    def _convert_result(self, result) -> dict[str, Any]:
+        """Convert V8 Dish object to Python dict."""
+        import STPyV8
+
+        result_type = int(result.type)
+        result_value = result.value
+
+        # DishType constants
+        ARRAY_BUFFER = 4
+        BYTE_ARRAY = 0
+
+        if result_type in (ARRAY_BUFFER, BYTE_ARRAY):
+            if isinstance(result_value, STPyV8.JSObject):
+                # Convert ArrayBuffer to list via JS
+                self._ctx.locals.array_buffer_value = result_value
+                result_value = list(self._ctx.eval("""
+                (function() {
+                    return Array.from(new Uint8Array(array_buffer_value));
+                })()
+                """))
+            elif hasattr(result_value, "__iter__"):
+                result_value = list(result_value)
+
+        return {"value": result_value, "type": result_type}

--- a/ida_cyberchef/runtime/stpyv8_runtime.py
+++ b/ida_cyberchef/runtime/stpyv8_runtime.py
@@ -63,6 +63,13 @@ class STPyV8Runtime(JSRuntime):
         globalThis.self = globalThis;
         globalThis.document = {};
 
+        // CyberChef app polyfill for window.app.options
+        globalThis.window.app = {
+            options: {
+                attemptHighlight: false
+            }
+        };
+
         // Minimal process polyfill
         globalThis.process = {
             platform: 'linux',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "pydantic>=2.0",
     "pyside6>=6.10.0",
     "rich>=13.0.0",
-    "stpyv8>=13.1.201.22",
+    "quickjs>=1.19.2",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,13 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Alternative JavaScript runtimes. QuickJS is included by default.
+# STPyV8 has better compatibility but larger binary size (~50MB).
+# PythonMonkey uses SpiderMonkey and has good interop.
+stpyv8 = ["stpyv8>=13.1.201.22"]
+pythonmonkey = ["pythonmonkey>=1.0.0"]
+
+[dependency-groups]
 dev = [
     "pytest>=8.4.2",
     "pytest-qt>=4.0",

--- a/readme.md
+++ b/readme.md
@@ -33,13 +33,20 @@ CyberChef is written in JavaScript, so we need a JS engine to execute it from Py
 
 | Runtime | Package size | Notes |
 |---------|--------------|-------|
-| [QuickJS](https://pypi.org/project/quickjs/) | ~300KB | Default. Some operations (compression) fall back to Python stdlib. |
-| [STPyV8](https://github.com/area1/stpyv8) | ~50MB | V8 engine. Best compatibility, all operations work natively. |
-| [PythonMonkey](https://github.com/Distributive-Network/PythonMonkey) | ~15MB | SpiderMonkey engine. Good interop, actively developed. |
+| [QuickJS](https://pypi.org/project/quickjs/) | ~300KB | Default. No WebAssembly support, some operations unavailable. |
+| [STPyV8](https://github.com/area1/stpyv8) | ~50MB | V8 engine. Full compatibility, all operations work. |
+| [PythonMonkey](https://github.com/Distributive-Network/PythonMonkey) | ~15MB | SpiderMonkey engine. WebAssembly support, good interop. |
 
-QuickJS is installed by default. It handles most operations fine, but has stricter typed array bounds checking that breaks CyberChef's embedded zlib implementation. For compression operations (Gzip, Zlib Deflate, etc.), we transparently route to Python's stdlib instead.
+QuickJS is installed by default. It handles most operations fine, but has two limitations:
 
-If you want full native compatibility, install one of the alternative runtimes:
+1. No WebAssembly support. Operations that use WASM modules will fail:
+   - Argon2 / Argon2 Compare
+   - Bcrypt / Bcrypt Compare / Bcrypt Parse
+   - YARA Rules
+
+2. Stricter typed array bounds checking breaks CyberChef's embedded zlib. Compression operations (Gzip, Zlib Deflate, Bzip2, etc.) transparently fall back to Python's stdlib.
+
+If you need the WASM-dependent operations, install one of the alternative runtimes:
 
 ```bash
 pip install ida-cyberchef[stpyv8]

--- a/readme.md
+++ b/readme.md
@@ -21,11 +21,38 @@ This project eliminates that workflow. It embeds CyberChef's JavaScript engine d
 
 ## How it works
 
-We use [STPyV8](https://github.com/area1/stpyv8) to run CyberChef's JavaScript code inside Python. The `ida_cyberchef.cyberchef` module loads CyberChef's bundle, sets up polyfills for browser/Node.js APIs it expects, and exposes a clean `bake()` function that takes binary data and a recipe.
+We run CyberChef's JavaScript code inside Python using a pluggable runtime system. The `ida_cyberchef.cyberchef` module loads CyberChef's bundle, sets up polyfills for browser/Node.js APIs it expects, and exposes a clean `bake()` function that takes binary data and a recipe.
 
 Then, we have a PySide6 Qt widget that exposes the recipe composer with the input/output hex dumps. The UI updates reactively - change the input or tweak an operation argument, and after a brief debounce, the entire pipeline re-executes and updates the output.
 
 As a minor extension beyond traditional CyberChef, each operation step can be expanded to preview intermediate results, which might be useful for debugging complex recipes.
+
+## JavaScript runtimes
+
+CyberChef is written in JavaScript, so we need a JS engine to execute it from Python. The project supports three runtimes with different tradeoffs:
+
+| Runtime | Package size | Notes |
+|---------|--------------|-------|
+| [QuickJS](https://pypi.org/project/quickjs/) | ~300KB | Default. Some operations (compression) fall back to Python stdlib. |
+| [STPyV8](https://github.com/area1/stpyv8) | ~50MB | V8 engine. Best compatibility, all operations work natively. |
+| [PythonMonkey](https://github.com/Distributive-Network/PythonMonkey) | ~15MB | SpiderMonkey engine. Good interop, actively developed. |
+
+QuickJS is installed by default. It handles most operations fine, but has stricter typed array bounds checking that breaks CyberChef's embedded zlib implementation. For compression operations (Gzip, Zlib Deflate, etc.), we transparently route to Python's stdlib instead.
+
+If you want full native compatibility, install one of the alternative runtimes:
+
+```bash
+pip install ida-cyberchef[stpyv8]
+# or
+pip install ida-cyberchef[pythonmonkey]
+```
+
+The runtime is auto-selected at startup based on what's installed, preferring STPyV8 > PythonMonkey > QuickJS. You can also force a specific runtime:
+
+```python
+from ida_cyberchef.cyberchef import load_cyberchef
+load_cyberchef(preferred_runtime="quickjs")
+```
 
 ## Background
 
@@ -60,10 +87,16 @@ To run the plugin in IDA, symlink the development directory into `$IDAUSR/plugin
 ln -s (pwd) ~/.idapro/plugins/ida-cyberchef
 ```
 
-You'll also want to install the dependencies into your IDA Pro Python virtual environment, something like:
+You'll also want to install the dependencies into your IDA Pro Python virtual environment:
 
 ```
-~/.idapro/venv/bin/python -m pip install STPyV8 pydantic
+~/.idapro/venv/bin/python -m pip install ida-cyberchef
+```
+
+Or if you want the V8 runtime for better compatibility:
+
+```
+~/.idapro/venv/bin/python -m pip install ida-cyberchef[stpyv8]
 ```
 
 Also, you can run the standalone QApplication (outside of IDA Pro) like this:
@@ -74,9 +107,9 @@ uv run cyberchef-qt
 
 ## Future Work
 
-I'm not quite sure if this will survive or not - I started out to prove this could work, and then was surprised when things fell into place. The architecture is a little ugly: running V8 from Python inside IDA to load a huge blob from GCHQ. But, it works, and we benefit from the operations already supported by CyberChef. So, if you want to propose enhancements and bug fixes, go for it!
+I'm not quite sure if this will survive or not - I started out to prove this could work, and then was surprised when things fell into place. The architecture is a little ugly: running a JS engine from Python inside IDA to load a huge blob from GCHQ. But, it works, and we benefit from the operations already supported by CyberChef. So, if you want to propose enhancements and bug fixes, go for it!
 
-There's some risk that the underlying Javascript engine (STPyV8, though I also worked with PythonMonkey) might become unmaintained or not build/work with future versions of Python or IDA Pro. That'll be a good time to re-evaluate the best parts of ida-cyberchef and perhaps rebuild them carefully.
+There's some risk that the underlying JavaScript engines might become unmaintained or not build/work with future versions of Python or IDA Pro. The pluggable runtime system mitigates this - if one engine breaks, you can switch to another. That said, if all three engines become unusable, that'll be a good time to re-evaluate the best parts of ida-cyberchef and perhaps rebuild them carefully.
 
 ## License
 

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -1,0 +1,562 @@
+"""Comprehensive tests for compression operations.
+
+These operations use Python's stdlib (zlib, gzip, bz2) as fallbacks because
+QuickJS has stricter typed array bounds checking that causes CyberChef's
+embedded zlib.js to fail.
+"""
+
+import gzip
+import zlib
+import bz2
+import pytest
+
+from ida_cyberchef.cyberchef import bake
+
+
+# =============================================================================
+# ZLIB DEFLATE / INFLATE
+# =============================================================================
+
+class TestZlibDeflate:
+    """Test Zlib Deflate compression."""
+
+    def test_basic_compression(self):
+        """Test basic zlib compression."""
+        result = bake(b"hello world", ["Zlib Deflate"])
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+        # Zlib header starts with 0x78
+        assert result[0] == 0x78
+
+    def test_empty_input(self):
+        """Test compression of empty data."""
+        result = bake(b"", ["Zlib Deflate"])
+        assert isinstance(result, bytes)
+        # Empty zlib compressed data is still valid
+        assert result[0] == 0x78
+
+    def test_short_input(self):
+        """Test compression of very short data."""
+        result = bake(b"a", ["Zlib Deflate"])
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    def test_repetitive_data_compression_ratio(self):
+        """Test that repetitive data compresses well."""
+        original = b"AAAAAAAAAA" * 100  # 1000 bytes of A's
+        result = bake(original, ["Zlib Deflate"])
+        # Should compress to much smaller size
+        assert len(result) < len(original) / 5
+
+    def test_binary_data(self):
+        """Test compression of binary data."""
+        original = bytes(range(256)) * 4
+        result = bake(original, ["Zlib Deflate"])
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    def test_compression_type_dynamic(self):
+        """Test with Dynamic Huffman Coding (default)."""
+        result = bake(b"test data", [{"op": "Zlib Deflate", "args": {"Compression type": "Dynamic Huffman Coding"}}])
+        assert isinstance(result, bytes)
+
+    def test_compression_type_fixed(self):
+        """Test with Fixed Huffman Coding."""
+        result = bake(b"test data", [{"op": "Zlib Deflate", "args": {"Compression type": "Fixed Huffman Coding"}}])
+        assert isinstance(result, bytes)
+
+    def test_compression_type_store(self):
+        """Test with None (Store) - no compression."""
+        original = b"test data"
+        result = bake(original, [{"op": "Zlib Deflate", "args": {"Compression type": "None (Store)"}}])
+        assert isinstance(result, bytes)
+        # Store mode should be larger or equal (header overhead)
+        assert len(result) >= len(original)
+
+    def test_large_data(self):
+        """Test compression of larger data."""
+        original = b"The quick brown fox jumps over the lazy dog. " * 1000
+        result = bake(original, ["Zlib Deflate"])
+        assert isinstance(result, bytes)
+        assert len(result) < len(original)
+
+    def test_string_input(self):
+        """Test that string input is handled correctly."""
+        result = bake("hello world", ["Zlib Deflate"])
+        assert isinstance(result, bytes)
+
+
+class TestZlibInflate:
+    """Test Zlib Inflate decompression."""
+
+    def test_basic_decompression(self):
+        """Test basic zlib decompression."""
+        compressed = zlib.compress(b"hello world")
+        result = bake(compressed, ["Zlib Inflate"])
+        assert result == b"hello world"
+
+    def test_empty_decompression(self):
+        """Test decompression of empty compressed data."""
+        compressed = zlib.compress(b"")
+        result = bake(compressed, ["Zlib Inflate"])
+        assert result == b""
+
+    def test_large_decompression(self):
+        """Test decompression of larger data."""
+        original = b"test data " * 10000
+        compressed = zlib.compress(original)
+        result = bake(compressed, ["Zlib Inflate"])
+        assert result == original
+
+    def test_start_index(self):
+        """Test decompression with start index."""
+        # Prepend some garbage bytes
+        garbage = b"GARBAGE"
+        compressed = zlib.compress(b"hello")
+        data = garbage + compressed
+        result = bake(data, [{"op": "Zlib Inflate", "args": {"Start index": len(garbage)}}])
+        assert result == b"hello"
+
+
+class TestZlibRoundtrip:
+    """Test Zlib compression/decompression roundtrip."""
+
+    def test_simple_roundtrip(self):
+        """Test simple compress/decompress cycle."""
+        original = b"hello world"
+        result = bake(original, ["Zlib Deflate", "Zlib Inflate"])
+        assert result == original
+
+    def test_binary_roundtrip(self):
+        """Test binary data roundtrip."""
+        original = bytes(range(256))
+        result = bake(original, ["Zlib Deflate", "Zlib Inflate"])
+        assert result == original
+
+    def test_large_roundtrip(self):
+        """Test large data roundtrip."""
+        original = b"Lorem ipsum dolor sit amet. " * 5000
+        result = bake(original, ["Zlib Deflate", "Zlib Inflate"])
+        assert result == original
+
+    def test_empty_roundtrip(self):
+        """Test empty data roundtrip."""
+        result = bake(b"", ["Zlib Deflate", "Zlib Inflate"])
+        assert result == b""
+
+    def test_unicode_roundtrip(self):
+        """Test UTF-8 encoded unicode roundtrip."""
+        original = "Hello 世界 🌍".encode("utf-8")
+        result = bake(original, ["Zlib Deflate", "Zlib Inflate"])
+        assert result == original
+
+
+# =============================================================================
+# RAW DEFLATE / INFLATE
+# =============================================================================
+
+class TestRawDeflate:
+    """Test Raw Deflate compression (no zlib header)."""
+
+    def test_basic_compression(self):
+        """Test basic raw deflate compression."""
+        result = bake(b"hello world", ["Raw Deflate"])
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+        # Raw deflate does NOT start with 0x78 (no zlib header)
+        assert result[0] != 0x78 or len(result) < 3
+
+    def test_empty_input(self):
+        """Test compression of empty data."""
+        result = bake(b"", ["Raw Deflate"])
+        assert isinstance(result, bytes)
+
+    def test_compression_types(self):
+        """Test different compression types."""
+        data = b"test data for compression"
+
+        dynamic = bake(data, [{"op": "Raw Deflate", "args": {"Compression type": "Dynamic Huffman Coding"}}])
+        fixed = bake(data, [{"op": "Raw Deflate", "args": {"Compression type": "Fixed Huffman Coding"}}])
+        store = bake(data, [{"op": "Raw Deflate", "args": {"Compression type": "None (Store)"}}])
+
+        assert isinstance(dynamic, bytes)
+        assert isinstance(fixed, bytes)
+        assert isinstance(store, bytes)
+
+
+class TestRawInflate:
+    """Test Raw Inflate decompression."""
+
+    def test_basic_decompression(self):
+        """Test basic raw inflate decompression."""
+        # Create raw deflate data using Python
+        compressor = zlib.compressobj(level=6, wbits=-15)
+        compressed = compressor.compress(b"hello world") + compressor.flush()
+
+        result = bake(compressed, ["Raw Inflate"])
+        assert result == b"hello world"
+
+    def test_start_index(self):
+        """Test decompression with start index."""
+        compressor = zlib.compressobj(level=6, wbits=-15)
+        compressed = compressor.compress(b"hello") + compressor.flush()
+
+        garbage = b"XX"
+        data = garbage + compressed
+        result = bake(data, [{"op": "Raw Inflate", "args": {"Start index": 2}}])
+        assert result == b"hello"
+
+
+class TestRawDeflateRoundtrip:
+    """Test Raw Deflate roundtrip."""
+
+    def test_simple_roundtrip(self):
+        """Test simple compress/decompress cycle."""
+        original = b"hello world"
+        result = bake(original, ["Raw Deflate", "Raw Inflate"])
+        assert result == original
+
+    def test_binary_roundtrip(self):
+        """Test binary data roundtrip."""
+        original = bytes(range(256))
+        result = bake(original, ["Raw Deflate", "Raw Inflate"])
+        assert result == original
+
+    def test_large_roundtrip(self):
+        """Test large data roundtrip."""
+        original = b"Test pattern. " * 10000
+        result = bake(original, ["Raw Deflate", "Raw Inflate"])
+        assert result == original
+
+
+# =============================================================================
+# GZIP / GUNZIP
+# =============================================================================
+
+class TestGzip:
+    """Test Gzip compression."""
+
+    def test_basic_compression(self):
+        """Test basic gzip compression."""
+        result = bake(b"hello world", ["Gzip"])
+        assert isinstance(result, bytes)
+        # Gzip magic number
+        assert result[:2] == b"\x1f\x8b"
+
+    def test_empty_input(self):
+        """Test compression of empty data."""
+        result = bake(b"", ["Gzip"])
+        assert isinstance(result, bytes)
+        assert result[:2] == b"\x1f\x8b"
+
+    def test_compression_ratio(self):
+        """Test that repetitive data compresses."""
+        original = b"AAAAAAAAAA" * 100
+        result = bake(original, ["Gzip"])
+        assert len(result) < len(original) / 5
+
+    def test_compression_types(self):
+        """Test different compression types."""
+        data = b"test data for gzip"
+
+        dynamic = bake(data, [{"op": "Gzip", "args": {"Compression type": "Dynamic Huffman Coding"}}])
+        fixed = bake(data, [{"op": "Gzip", "args": {"Compression type": "Fixed Huffman Coding"}}])
+
+        assert dynamic[:2] == b"\x1f\x8b"
+        assert fixed[:2] == b"\x1f\x8b"
+
+    def test_stdlib_compatibility(self):
+        """Test that output is compatible with Python's gzip."""
+        original = b"hello world"
+        compressed = bake(original, ["Gzip"])
+
+        # Should be decompressible by Python's gzip
+        decompressed = gzip.decompress(compressed)
+        assert decompressed == original
+
+
+class TestGunzip:
+    """Test Gunzip decompression."""
+
+    def test_basic_decompression(self):
+        """Test basic gunzip decompression."""
+        compressed = gzip.compress(b"hello world")
+        result = bake(compressed, ["Gunzip"])
+        assert result == b"hello world"
+
+    def test_empty_decompression(self):
+        """Test decompression of empty gzipped data."""
+        compressed = gzip.compress(b"")
+        result = bake(compressed, ["Gunzip"])
+        assert result == b""
+
+    def test_large_decompression(self):
+        """Test decompression of larger data."""
+        original = b"decompression test " * 10000
+        compressed = gzip.compress(original)
+        result = bake(compressed, ["Gunzip"])
+        assert result == original
+
+    def test_multi_member(self):
+        """Test decompression of data compressed externally."""
+        # Create gzip data that might come from external tools
+        original = b"data from external source"
+        compressed = gzip.compress(original)
+        result = bake(compressed, ["Gunzip"])
+        assert result == original
+
+
+class TestGzipRoundtrip:
+    """Test Gzip roundtrip."""
+
+    def test_simple_roundtrip(self):
+        """Test simple compress/decompress cycle."""
+        original = b"hello world"
+        result = bake(original, ["Gzip", "Gunzip"])
+        assert result == original
+
+    def test_binary_roundtrip(self):
+        """Test binary data roundtrip."""
+        original = bytes(range(256))
+        result = bake(original, ["Gzip", "Gunzip"])
+        assert result == original
+
+    def test_large_roundtrip(self):
+        """Test large data roundtrip."""
+        original = b"Gzip test pattern! " * 10000
+        result = bake(original, ["Gzip", "Gunzip"])
+        assert result == original
+
+    def test_unicode_roundtrip(self):
+        """Test UTF-8 unicode roundtrip."""
+        original = "Привет мир! 你好世界!".encode("utf-8")
+        result = bake(original, ["Gzip", "Gunzip"])
+        assert result == original
+
+
+# =============================================================================
+# BZIP2 COMPRESS / DECOMPRESS
+# =============================================================================
+
+class TestBzip2Compress:
+    """Test Bzip2 compression."""
+
+    def test_basic_compression(self):
+        """Test basic bzip2 compression."""
+        result = bake(b"hello world", ["Bzip2 Compress"])
+        assert isinstance(result, bytes)
+        # Bzip2 magic number
+        assert result[:2] == b"BZ"
+
+    def test_empty_input(self):
+        """Test compression of empty data."""
+        result = bake(b"", ["Bzip2 Compress"])
+        assert isinstance(result, bytes)
+
+    def test_compression_ratio(self):
+        """Test compression of repetitive data."""
+        original = b"BZIP2TEST" * 100
+        result = bake(original, ["Bzip2 Compress"])
+        assert len(result) < len(original) / 3
+
+    def test_block_size(self):
+        """Test different block sizes."""
+        data = b"test data " * 100
+
+        small_block = bake(data, [{"op": "Bzip2 Compress", "args": {"Block size (100s of kb)": 1}}])
+        large_block = bake(data, [{"op": "Bzip2 Compress", "args": {"Block size (100s of kb)": 9}}])
+
+        assert small_block[:2] == b"BZ"
+        assert large_block[:2] == b"BZ"
+
+    def test_stdlib_compatibility(self):
+        """Test that output is compatible with Python's bz2."""
+        original = b"hello world"
+        compressed = bake(original, ["Bzip2 Compress"])
+
+        # Should be decompressible by Python's bz2
+        decompressed = bz2.decompress(compressed)
+        assert decompressed == original
+
+
+class TestBzip2Decompress:
+    """Test Bzip2 decompression."""
+
+    def test_basic_decompression(self):
+        """Test basic bzip2 decompression."""
+        compressed = bz2.compress(b"hello world")
+        result = bake(compressed, ["Bzip2 Decompress"])
+        assert result == b"hello world"
+
+    def test_empty_decompression(self):
+        """Test decompression of empty bzip2 data."""
+        compressed = bz2.compress(b"")
+        result = bake(compressed, ["Bzip2 Decompress"])
+        assert result == b""
+
+    def test_large_decompression(self):
+        """Test decompression of larger data."""
+        original = b"bzip2 decompression test " * 5000
+        compressed = bz2.compress(original)
+        result = bake(compressed, ["Bzip2 Decompress"])
+        assert result == original
+
+
+class TestBzip2Roundtrip:
+    """Test Bzip2 roundtrip."""
+
+    def test_simple_roundtrip(self):
+        """Test simple compress/decompress cycle."""
+        original = b"hello world"
+        result = bake(original, ["Bzip2 Compress", "Bzip2 Decompress"])
+        assert result == original
+
+    def test_binary_roundtrip(self):
+        """Test binary data roundtrip."""
+        original = bytes(range(256))
+        result = bake(original, ["Bzip2 Compress", "Bzip2 Decompress"])
+        assert result == original
+
+    def test_large_roundtrip(self):
+        """Test large data roundtrip."""
+        original = b"Bzip2 pattern! " * 10000
+        result = bake(original, ["Bzip2 Compress", "Bzip2 Decompress"])
+        assert result == original
+
+
+# =============================================================================
+# MIXED OPERATIONS (Compression + Other Operations)
+# =============================================================================
+
+class TestMixedOperations:
+    """Test compression operations mixed with other CyberChef operations."""
+
+    def test_base64_then_compress(self):
+        """Test Base64 encoding followed by compression."""
+        original = b"hello world"
+        result = bake(original, ["To Base64", "Gzip"])
+        assert result[:2] == b"\x1f\x8b"
+
+    def test_compress_then_hex(self):
+        """Test compression followed by hex encoding."""
+        original = b"test"
+        result = bake(original, ["Gzip", "To Hex"])
+        assert "1f 8b" in result  # Gzip magic in hex
+
+    def test_hex_decompress_chain(self):
+        """Test hex decode then decompress."""
+        compressed = gzip.compress(b"hello")
+        hex_data = compressed.hex()
+        result = bake(hex_data, ["From Hex", "Gunzip"])
+        assert result == b"hello"
+
+    def test_compress_hash(self):
+        """Test compression followed by hashing."""
+        original = b"test data"
+        result = bake(original, ["Zlib Deflate", "MD5"])
+        assert len(result) == 32  # MD5 hash length
+
+    def test_complex_chain(self):
+        """Test complex chain with compression in the middle."""
+        original = b"The quick brown fox"
+        result = bake(original, [
+            "To Base64",       # QuickJS
+            "Gzip",            # Python
+            "To Hex",          # QuickJS
+            "From Hex",        # QuickJS
+            "Gunzip",          # Python
+            "From Base64"      # QuickJS
+        ])
+        assert result == original
+
+    def test_multiple_compressions(self):
+        """Test chaining different compression algorithms."""
+        original = b"multi-compression test"
+
+        # Compress with one, decompress, compress with another
+        result = bake(original, [
+            "Gzip",
+            "Gunzip",
+            "Zlib Deflate",
+            "Zlib Inflate",
+            "Bzip2 Compress",
+            "Bzip2 Decompress"
+        ])
+        assert result == original
+
+    def test_compress_between_transforms(self):
+        """Test compression between string transformations."""
+        original = "hello world"
+        result = bake(original, [
+            "To Upper case",
+            "Gzip",
+            "Gunzip",
+            "To Lower case"
+        ])
+        # After upper -> compress -> decompress -> lower
+        assert result == "hello world"
+
+
+# =============================================================================
+# EDGE CASES AND ERROR HANDLING
+# =============================================================================
+
+class TestEdgeCases:
+    """Test edge cases and potential error conditions."""
+
+    def test_very_small_data(self):
+        """Test compression of 1-byte data."""
+        for algo in ["Zlib Deflate", "Raw Deflate", "Gzip", "Bzip2 Compress"]:
+            result = bake(b"X", [algo])
+            assert isinstance(result, bytes)
+
+    def test_null_bytes(self):
+        """Test compression of data with null bytes."""
+        original = b"\x00\x00\x00\x00"
+        for algo_pair in [
+            ("Zlib Deflate", "Zlib Inflate"),
+            ("Raw Deflate", "Raw Inflate"),
+            ("Gzip", "Gunzip"),
+            ("Bzip2 Compress", "Bzip2 Decompress"),
+        ]:
+            result = bake(original, list(algo_pair))
+            assert result == original
+
+    def test_high_entropy_data(self):
+        """Test compression of high-entropy (random-like) data."""
+        # High entropy data doesn't compress well
+        import os
+        original = os.urandom(1000)
+
+        compressed = bake(original, ["Zlib Deflate"])
+        # Should still work, even if not much smaller
+        assert isinstance(compressed, bytes)
+
+        # Roundtrip should work
+        result = bake(compressed, ["Zlib Inflate"])
+        assert result == original
+
+    def test_repeated_compression(self):
+        """Test compressing already-compressed data."""
+        original = b"test data"
+
+        # Double compress
+        double_compressed = bake(original, ["Gzip", "Gzip"])
+        assert double_compressed[:2] == b"\x1f\x8b"
+
+        # Double decompress
+        result = bake(double_compressed, ["Gunzip", "Gunzip"])
+        assert result == original
+
+    def test_all_byte_values(self):
+        """Test compression with all possible byte values."""
+        original = bytes(range(256))
+
+        for algo_pair in [
+            ("Zlib Deflate", "Zlib Inflate"),
+            ("Raw Deflate", "Raw Inflate"),
+            ("Gzip", "Gunzip"),
+            ("Bzip2 Compress", "Bzip2 Decompress"),
+        ]:
+            result = bake(original, list(algo_pair))
+            assert result == original, f"Failed for {algo_pair}"

--- a/tests/test_cyberchef.py
+++ b/tests/test_cyberchef.py
@@ -3,69 +3,47 @@ import hashlib
 from ida_cyberchef.cyberchef import bake, get_chef, plate
 
 
-def rechef(dish_result, chef):
-    """Convert a CyberChef Dish result back to a proper Dish for the next operation.
-
-    This does a double-plate: Dish -> Python type -> Dish
-    Needed if Dish objects don't cross the Python/JS boundary cleanly.
-
-    Args:
-        dish_result: CyberChef Dish result from previous operation
-        chef: CyberChef module instance
-
-    Returns: Fresh Dish instance for next operation
-    """
-    return plate(plate(dish_result), chef)
-
-
 def test_from_base64():
-    chef = get_chef()
+    """Test From Base64 operation."""
     test_input = "U28gbG9uZyBhbmQgdGhhbmtzIGZvciBhbGwgdGhlIGZpc2gu"
-    result = plate(chef.fromBase64(test_input))
+    result = bake(test_input, ["From Base64"])
     assert result == b"So long and thanks for all the fish."
 
 
 def test_to_hex():
-    chef = get_chef()
-    input_dish = plate(b"hello", chef)
-    result = plate(chef.toHex(input_dish))
+    """Test To Hex operation."""
+    result = bake(b"hello", ["To Hex"])
     assert result == "68 65 6c 6c 6f"
 
 
 def test_md5():
-    chef = get_chef()
-    input_dish = plate(b"hello", chef)
-    result = plate(chef.MD5(input_dish))
+    """Test MD5 operation."""
+    result = bake(b"hello", ["MD5"])
     assert result == "5d41402abc4b2a76b9719d911017c592"
 
 
-def test_chained_operations_with_rechef():
-    """Test chaining with rechef() if needed."""
-    chef = get_chef()
-
-    input_dish = plate(b"hello", chef)
-    step1 = chef.toHex(input_dish)
-    step2 = rechef(chef.fromHex(step1), chef)
-    step3 = chef.MD5(step2)
-    result = plate(step3)
-
+def test_chained_operations():
+    """Test chaining operations."""
+    result = bake(b"hello", ["To Hex", "From Hex", "MD5"])
     expected = "5d41402abc4b2a76b9719d911017c592"
     assert result == expected
 
 
 def test_translate_datetime():
-    chef = get_chef()
-    result = plate(
-        chef.translateDateTimeFormat(
-            "15/06/2015 20:45:00", {"outputTimezone": "Australia/Queensland"}
-        )
+    """Test Translate DateTime Format operation."""
+    result = bake(
+        "15/06/2015 20:45:00",
+        [{"op": "Translate DateTime Format", "args": {"outputTimezone": "Australia/Queensland"}}],
     )
     assert "2015" in result
 
 
 def test_parse_ipv6():
-    chef = get_chef()
-    result = plate(chef.parseIPv6Address("2001:0000:4136:e378:8000:63bf:3fff:fdd2"))
+    """Test Parse IPv6 address operation."""
+    result = bake(
+        "2001:0000:4136:e378:8000:63bf:3fff:fdd2",
+        ["Parse IPv6 address"],
+    )
     assert "2001:0:4136:e378:8000:63bf:3fff:fdd2" in result
 
 
@@ -74,17 +52,14 @@ def test_sha256():
 
     Note: size must be a string "256", not integer 256.
     """
-
-    chef = get_chef()
-    input_dish = plate(b"hello", chef)
-    result = plate(chef.SHA2(input_dish, {"size": "256"}))
+    result = bake(b"hello", [{"op": "SHA2", "args": {"size": "256"}}])
     expected = hashlib.sha256(b"hello").hexdigest()
     assert result == expected
 
 
 def test_url_encode():
-    chef = get_chef()
-    result = plate(chef.URLEncode("Hello World!"))
+    """Test URL Encode operation."""
+    result = bake("Hello World!", ["URL Encode"])
     assert result == "Hello%20World!"
 
 
@@ -184,3 +159,27 @@ def test_bake_empty_recipe():
     """Test bake with empty recipe returns input unchanged."""
     result = bake(b"hello", [])
     assert result == b"hello" or result == "hello"
+
+
+def test_plate_bytes():
+    """Test plate converts bytes to Dish format."""
+    dish = plate(b"hello")
+    assert isinstance(dish, dict)
+    assert "value" in dish
+    assert "type" in dish
+
+
+def test_plate_string():
+    """Test plate converts string to Dish format."""
+    dish = plate("hello")
+    assert isinstance(dish, dict)
+    assert dish["value"] == "hello"
+
+
+def test_get_chef():
+    """Test get_chef returns a valid context."""
+    chef = get_chef()
+    assert chef is not None
+    # Should return same instance on second call
+    chef2 = get_chef()
+    assert chef is chef2

--- a/tests/test_operations_comprehensive.py
+++ b/tests/test_operations_comprehensive.py
@@ -1,0 +1,742 @@
+"""Comprehensive test suite for CyberChef operations with QuickJS backend.
+
+This tests a wide variety of operations to verify which ones work correctly
+with the QuickJS JavaScript engine.
+"""
+
+import hashlib
+import base64
+import pytest
+
+from ida_cyberchef.cyberchef import bake
+
+
+# =============================================================================
+# ENCODING / DECODING OPERATIONS
+# =============================================================================
+
+class TestBaseEncodings:
+    """Test base encoding/decoding operations."""
+
+    def test_to_base64(self):
+        result = bake(b"hello world", ["To Base64"])
+        assert result == "aGVsbG8gd29ybGQ="
+
+    def test_from_base64(self):
+        result = bake("aGVsbG8gd29ybGQ=", ["From Base64"])
+        assert result == b"hello world"
+
+    def test_base64_roundtrip(self):
+        original = b"The quick brown fox jumps over the lazy dog"
+        result = bake(original, ["To Base64", "From Base64"])
+        assert result == original
+
+    def test_to_base32(self):
+        result = bake(b"hello", ["To Base32"])
+        assert result == "NBSWY3DP"
+
+    def test_from_base32(self):
+        result = bake("NBSWY3DP", ["From Base32"])
+        assert result == b"hello"
+
+    def test_to_base58(self):
+        result = bake(b"hello", ["To Base58"])
+        assert len(result) > 0
+
+    def test_from_base58(self):
+        result = bake("Cn8eVZL", ["From Base58"])
+        assert isinstance(result, bytes)
+
+    def test_to_base62(self):
+        result = bake(b"hello", ["To Base62"])
+        assert len(result) > 0
+
+    def test_to_base85(self):
+        result = bake(b"hello", ["To Base85"])
+        assert len(result) > 0
+
+
+class TestHexEncodings:
+    """Test hexadecimal encoding/decoding."""
+
+    def test_to_hex(self):
+        result = bake(b"hello", ["To Hex"])
+        assert result == "68 65 6c 6c 6f"
+
+    def test_from_hex(self):
+        result = bake("68656c6c6f", ["From Hex"])
+        assert result == b"hello"
+
+    def test_hex_roundtrip(self):
+        original = bytes(range(256))
+        result = bake(original, ["To Hex", "From Hex"])
+        assert result == original
+
+    def test_to_hex_no_delimiter(self):
+        result = bake(b"AB", [{"op": "To Hex", "args": {"Delimiter": "None"}}])
+        assert result == "4142"
+
+
+class TestCharacterEncodings:
+    """Test character encoding operations."""
+
+    def test_to_charcode(self):
+        # To Charcode outputs hex by default
+        result = bake("ABC", ["To Charcode"])
+        assert "41" in result or "42" in result  # Hex codes
+
+    def test_from_charcode(self):
+        # From Charcode expects hex by default
+        result = bake("41 42 43", ["From Charcode"])
+        assert result == "ABC" or result == b"ABC"
+
+    def test_to_decimal(self):
+        result = bake(b"\x00\x01\x02", ["To Decimal"])
+        assert "0" in result and "1" in result and "2" in result
+
+    def test_from_decimal(self):
+        result = bake("0 1 2", ["From Decimal"])
+        assert result == b"\x00\x01\x02"
+
+    def test_to_binary(self):
+        result = bake(b"A", ["To Binary"])
+        assert "01000001" in result
+
+    def test_from_binary(self):
+        result = bake("01000001", ["From Binary"])
+        assert result == b"A"
+
+    def test_to_octal(self):
+        result = bake(b"A", ["To Octal"])
+        assert "101" in result  # Octal for 65
+
+    def test_from_octal(self):
+        result = bake("101", ["From Octal"])
+        assert result == b"A"
+
+
+class TestURLEncodings:
+    """Test URL encoding/decoding."""
+
+    def test_url_encode(self):
+        result = bake("Hello World!", ["URL Encode"])
+        assert result == "Hello%20World!"
+
+    def test_url_decode(self):
+        result = bake("Hello%20World%21", ["URL Decode"])
+        assert result == "Hello World!"
+
+
+class TestHTMLEncodings:
+    """Test HTML encoding/decoding."""
+
+    def test_html_entity_encode(self):
+        result = bake("<script>", ["To HTML Entity"])
+        assert "&lt;" in result or "&#" in result
+
+    def test_html_entity_decode(self):
+        result = bake("&lt;script&gt;", ["From HTML Entity"])
+        assert "<script>" in result
+
+
+# =============================================================================
+# HASHING OPERATIONS
+# =============================================================================
+
+class TestHashingMD:
+    """Test MD family hash operations."""
+
+    def test_md5(self):
+        result = bake(b"hello", ["MD5"])
+        expected = hashlib.md5(b"hello").hexdigest()
+        assert result == expected
+
+    def test_md4(self):
+        result = bake(b"hello", ["MD4"])
+        assert len(result) == 32  # MD4 produces 128-bit hash
+
+    def test_md2(self):
+        result = bake(b"hello", ["MD2"])
+        assert len(result) == 32
+
+
+class TestHashingSHA:
+    """Test SHA family hash operations."""
+
+    def test_sha1(self):
+        result = bake(b"hello", ["SHA1"])
+        expected = hashlib.sha1(b"hello").hexdigest()
+        assert result == expected
+
+    def test_sha256(self):
+        result = bake(b"hello", [{"op": "SHA2", "args": {"size": "256"}}])
+        expected = hashlib.sha256(b"hello").hexdigest()
+        assert result == expected
+
+    def test_sha384(self):
+        result = bake(b"hello", [{"op": "SHA2", "args": {"size": "384"}}])
+        expected = hashlib.sha384(b"hello").hexdigest()
+        assert result == expected
+
+    def test_sha512(self):
+        result = bake(b"hello", [{"op": "SHA2", "args": {"size": "512"}}])
+        expected = hashlib.sha512(b"hello").hexdigest()
+        assert result == expected
+
+    def test_sha3_256(self):
+        result = bake(b"hello", [{"op": "SHA3", "args": {"size": "256"}}])
+        expected = hashlib.sha3_256(b"hello").hexdigest()
+        assert result == expected
+
+    def test_sha3_512(self):
+        result = bake(b"hello", [{"op": "SHA3", "args": {"size": "512"}}])
+        expected = hashlib.sha3_512(b"hello").hexdigest()
+        assert result == expected
+
+
+class TestHashingOther:
+    """Test other hash operations."""
+
+    def test_ripemd(self):
+        result = bake(b"hello", ["RIPEMD"])
+        assert len(result) == 80  # RIPEMD-160/256/320 combined
+
+    def test_crc32(self):
+        result = bake(b"hello", [{"op": "CRC Checksum", "args": {"Algorithm": "CRC-32"}}])
+        assert len(result) == 8  # CRC-32 is 8 hex chars
+
+    def test_crc16(self):
+        result = bake(b"hello", [{"op": "CRC Checksum", "args": {"Algorithm": "CRC-16"}}])
+        assert len(result) > 0
+
+    def test_blake2b(self):
+        result = bake(b"hello", [{"op": "BLAKE2b", "args": {"size": "256"}}])
+        assert len(result) == 64  # 256 bits = 64 hex chars
+
+    def test_blake2s(self):
+        result = bake(b"hello", [{"op": "BLAKE2s", "args": {"size": "256"}}])
+        assert len(result) == 64
+
+
+class TestHMAC:
+    """Test HMAC operations."""
+
+    def test_hmac_md5(self):
+        result = bake(b"hello", [{"op": "HMAC", "args": {"Key": {"string": "key", "option": "UTF8"}, "Hashing function": "MD5"}}])
+        assert len(result) == 32
+
+    def test_hmac_sha256(self):
+        result = bake(b"hello", [{"op": "HMAC", "args": {"Key": {"string": "key", "option": "UTF8"}, "Hashing function": "SHA256"}}])
+        assert len(result) == 64
+
+
+# =============================================================================
+# STRING MANIPULATION OPERATIONS
+# =============================================================================
+
+class TestStringManipulation:
+    """Test string manipulation operations."""
+
+    def test_reverse(self):
+        result = bake("hello", ["Reverse"])
+        # May return bytes or string
+        assert result == "olleh" or result == b"olleh"
+
+    def test_upper_case(self):
+        result = bake("hello world", ["To Upper case"])
+        assert result == "HELLO WORLD"
+
+    def test_lower_case(self):
+        result = bake("HELLO WORLD", ["To Lower case"])
+        assert result == "hello world"
+
+    def test_split(self):
+        result = bake("a,b,c", [{"op": "Split", "args": {"Split delimiter": ","}}])
+        assert "a" in result
+
+    def test_add_line_numbers(self):
+        result = bake("line1\nline2", ["Add line numbers"])
+        assert "1" in result
+
+    def test_remove_line_numbers(self):
+        result = bake("1 line1\n2 line2", ["Remove line numbers"])
+        assert "line1" in result
+
+    def test_remove_whitespace(self):
+        result = bake("hello   world", [{"op": "Remove whitespace", "args": {"Spaces": True}}])
+        assert "helloworld" in result
+
+    def test_pad_lines(self):
+        result = bake("test", [{"op": "Pad lines", "args": {"Position": "Start", "Length": 10, "Character": " "}}])
+        assert len(result) >= 10
+
+    def test_head(self):
+        result = bake("line1\nline2\nline3", [{"op": "Head", "args": {"Number of lines": 1}}])
+        assert "line1" in result
+
+    def test_tail(self):
+        result = bake("line1\nline2\nline3", [{"op": "Tail", "args": {"Number of lines": 1}}])
+        assert "line3" in result
+
+    def test_sort(self):
+        result = bake("c\na\nb", ["Sort"])
+        assert result.startswith("a") or "a\nb\nc" in result
+
+    def test_unique(self):
+        result = bake("a\na\nb\nb", ["Unique"])
+        assert result.count("a") == 1 or "a\nb" in result
+
+
+class TestEscaping:
+    """Test escape/unescape operations."""
+
+    def test_escape_string(self):
+        result = bake('hello\nworld', ["Escape string"])
+        assert "\\n" in result
+
+    def test_unescape_string(self):
+        result = bake('hello\\nworld', ["Unescape string"])
+        assert "hello" in result
+
+
+# =============================================================================
+# ARITHMETIC / LOGIC OPERATIONS
+# =============================================================================
+
+class TestArithmeticLogic:
+    """Test arithmetic and logic operations."""
+
+    def test_xor(self):
+        result = bake(b"hello", [{"op": "XOR", "args": {"Key": {"string": "key", "option": "UTF8"}}}])
+        assert isinstance(result, bytes)
+        assert len(result) == 5
+
+    def test_xor_roundtrip(self):
+        original = b"hello"
+        key_args = {"Key": {"string": "secret", "option": "UTF8"}}
+        encrypted = bake(original, [{"op": "XOR", "args": key_args}])
+        decrypted = bake(encrypted, [{"op": "XOR", "args": key_args}])
+        assert decrypted == original
+
+    def test_and(self):
+        result = bake(b"\xff\x00", [{"op": "AND", "args": {"Key": {"string": "f0", "option": "Hex"}}}])
+        assert isinstance(result, bytes)
+
+    def test_or(self):
+        result = bake(b"\x0f\x00", [{"op": "OR", "args": {"Key": {"string": "f0", "option": "Hex"}}}])
+        assert isinstance(result, bytes)
+
+    def test_not(self):
+        result = bake(b"\xff", ["NOT"])
+        assert result == b"\x00"
+
+    def test_add(self):
+        result = bake(b"\x01\x02", [{"op": "ADD", "args": {"Key": {"string": "01", "option": "Hex"}}}])
+        assert isinstance(result, bytes)
+
+    def test_subtract(self):
+        result = bake(b"\x02\x03", [{"op": "SUB", "args": {"Key": {"string": "01", "option": "Hex"}}}])
+        assert isinstance(result, bytes)
+
+    def test_bit_shift_left(self):
+        result = bake(b"\x01", [{"op": "Bit shift left", "args": {"Amount": 1}}])
+        assert result == b"\x02"
+
+    def test_bit_shift_right(self):
+        result = bake(b"\x02", [{"op": "Bit shift right", "args": {"Amount": 1}}])
+        assert result == b"\x01"
+
+    def test_rotate_left(self):
+        result = bake(b"\x80", [{"op": "Rotate left", "args": {"Amount": 1}}])
+        assert isinstance(result, bytes)
+
+    def test_rotate_right(self):
+        result = bake(b"\x01", [{"op": "Rotate right", "args": {"Amount": 1}}])
+        assert isinstance(result, bytes)
+
+
+# =============================================================================
+# DATA FORMAT OPERATIONS
+# =============================================================================
+
+class TestJSONOperations:
+    """Test JSON operations."""
+
+    def test_json_beautify(self):
+        result = bake('{"a":1,"b":2}', ["JSON Beautify"])
+        assert "a" in result
+        assert "\n" in result or "  " in result
+
+    def test_json_minify(self):
+        result = bake('{\n  "a": 1\n}', ["JSON Minify"])
+        assert result == '{"a":1}'
+
+    def test_json_to_csv(self):
+        result = bake('[{"a":1},{"a":2}]', ["JSON to CSV"])
+        assert "a" in result
+
+
+class TestXMLOperations:
+    """Test XML operations."""
+
+    def test_xml_beautify(self):
+        result = bake('<root><child>test</child></root>', ["XML Beautify"])
+        assert "<root>" in result
+
+    def test_xml_minify(self):
+        result = bake('<root>\n  <child>test</child>\n</root>', ["XML Minify"])
+        assert "<root>" in result
+
+
+class TestDateTimeOperations:
+    """Test date/time operations."""
+
+    def test_parse_unix_timestamp(self):
+        result = bake("1609459200", ["From UNIX Timestamp"])
+        assert "2021" in result or "Jan" in result
+
+    def test_to_unix_timestamp(self):
+        result = bake("2021-01-01 00:00:00", ["To UNIX Timestamp"])
+        assert "1609" in result
+
+
+# =============================================================================
+# CIPHER OPERATIONS (CLASSICAL)
+# =============================================================================
+
+class TestClassicalCiphers:
+    """Test classical cipher operations."""
+
+    def test_rot13(self):
+        result = bake("hello", ["ROT13"])
+        # May return bytes or string
+        assert result == "uryyb" or result == b"uryyb"
+
+    def test_rot13_roundtrip(self):
+        original = "TheQuickBrownFox"
+        result = bake(original, ["ROT13", "ROT13"])
+        assert result == original or result == original.encode()
+
+    def test_rot47(self):
+        result = bake("hello", ["ROT47"])
+        assert result != "hello"
+
+    def test_atbash(self):
+        result = bake("abc", ["Atbash Cipher"])
+        assert result == "zyx"
+
+    def test_vigenere_encode(self):
+        result = bake("hello", [{"op": "Vigenère Encode", "args": {"Key": "key"}}])
+        assert len(result) == 5
+        assert result != "hello"
+
+    def test_vigenere_decode(self):
+        encoded = bake("hello", [{"op": "Vigenère Encode", "args": {"Key": "key"}}])
+        decoded = bake(encoded, [{"op": "Vigenère Decode", "args": {"Key": "key"}}])
+        assert decoded.lower() == "hello"
+
+    def test_affine_cipher_encode(self):
+        result = bake("hello", [{"op": "Affine Cipher Encode", "args": {"a": 5, "b": 8}}])
+        assert len(result) == 5
+
+    def test_a1z26_encode(self):
+        result = bake("abc", ["A1Z26 Cipher Encode"])
+        assert "1" in result and "2" in result and "3" in result
+
+    def test_a1z26_decode(self):
+        result = bake("1 2 3", ["A1Z26 Cipher Decode"])
+        assert result.lower() == "abc"
+
+
+# =============================================================================
+# NETWORK OPERATIONS
+# =============================================================================
+
+class TestNetworkParsing:
+    """Test network-related parsing operations."""
+
+    def test_parse_ipv4(self):
+        result = bake("192.168.1.1", ["Parse IP range"])
+        assert "192.168.1.1" in result
+
+    def test_parse_ipv6(self):
+        result = bake("2001:0db8:85a3:0000:0000:8a2e:0370:7334", ["Parse IPv6 address"])
+        assert "2001" in result
+
+    def test_defang_ip(self):
+        result = bake("192.168.1.1", ["Defang IP Addresses"])
+        assert "[.]" in result
+
+    def test_defang_url(self):
+        result = bake("http://example.com", ["Defang URL"])
+        assert "[.]" in result or "hxxp" in result
+
+    def test_parse_uri(self):
+        result = bake("https://example.com:8080/path?query=1", ["Parse URI"])
+        assert "example.com" in result
+
+
+class TestExtractors:
+    """Test data extraction operations."""
+
+    def test_extract_urls(self):
+        result = bake("Visit https://example.com for more info", ["Extract URLs"])
+        assert "https://example.com" in result
+
+    def test_extract_email_addresses(self):
+        result = bake("Contact test@example.com for info", ["Extract email addresses"])
+        assert "test@example.com" in result
+
+    def test_extract_ip_addresses(self):
+        result = bake("Server at 192.168.1.1 is down", ["Extract IP addresses"])
+        assert "192.168.1.1" in result
+
+    def test_extract_file_paths(self):
+        result = bake("Open /etc/passwd for editing", ["Extract file paths"])
+        assert "/etc/passwd" in result
+
+    def test_extract_dates(self):
+        result = bake("Meeting on 2021-01-15", ["Extract dates"])
+        assert "2021" in result or "15" in result
+
+
+# =============================================================================
+# UTILITY OPERATIONS
+# =============================================================================
+
+class TestUtilityOps:
+    """Test utility operations."""
+
+    def test_detect_file_type(self):
+        # PNG header
+        result = bake(b"\x89PNG\r\n\x1a\n", ["Detect File Type"])
+        assert "PNG" in result or "image" in result.lower()
+
+    def test_generate_uuid(self):
+        result = bake("", ["Generate UUID"])
+        assert "-" in result
+        assert len(result) == 36
+
+    def test_generate_lorem_ipsum(self):
+        result = bake("", [{"op": "Generate Lorem Ipsum", "args": {"paragraphs": 1}}])
+        assert "Lorem" in result or "ipsum" in result.lower() or len(result) > 10
+
+
+# =============================================================================
+# QUOTING OPERATIONS
+# =============================================================================
+
+class TestQuoting:
+    """Test quoting operations."""
+
+    def test_to_quoted_printable(self):
+        result = bake("hello=world", ["To Quoted Printable"])
+        assert "=3D" in result  # = is encoded as =3D
+
+    def test_from_quoted_printable(self):
+        result = bake("hello=3Dworld", ["From Quoted Printable"])
+        # May not work perfectly
+        assert "hello" in result
+
+
+# =============================================================================
+# SPECIAL ENCODINGS
+# =============================================================================
+
+class TestSpecialEncodings:
+    """Test special encoding operations."""
+
+    def test_to_morse_code(self):
+        result = bake("SOS", ["To Morse Code"])
+        assert "..." in result and "---" in result
+
+    def test_from_morse_code(self):
+        result = bake("... --- ...", ["From Morse Code"])
+        assert result.upper() == "SOS"
+
+    def test_to_braille(self):
+        result = bake("hello", ["To Braille"])
+        assert len(result) > 0
+
+    def test_from_braille(self):
+        braille = bake("hello", ["To Braille"])
+        result = bake(braille, ["From Braille"])
+        assert "hello" in result.lower()
+
+    def test_encode_text_to_binary(self):
+        result = bake("A", ["To Binary"])
+        assert "01000001" in result
+
+
+# =============================================================================
+# CHAINED OPERATIONS
+# =============================================================================
+
+class TestChainedOperations:
+    """Test complex chains of operations."""
+
+    def test_encode_decode_chain(self):
+        """Test multiple encode/decode operations in sequence."""
+        original = b"test data"
+        result = bake(original, [
+            "To Base64",
+            "To Hex",
+            "From Hex",
+            "From Base64"
+        ])
+        assert result == original
+
+    def test_hash_chain(self):
+        """Test chaining multiple hash operations."""
+        result = bake(b"hello", ["MD5", "SHA1"])
+        # Should be SHA1 of the MD5 hash string
+        md5_hash = hashlib.md5(b"hello").hexdigest()
+        expected = hashlib.sha1(md5_hash.encode()).hexdigest()
+        assert result == expected
+
+    def test_transform_chain(self):
+        """Test chaining string transformations."""
+        result = bake("hello world", [
+            "To Upper case",
+            "Reverse",
+            "To Lower case"
+        ])
+        # May be bytes or string
+        expected = "dlrow olleh"
+        assert result == expected or result == expected.encode()
+
+    def test_complex_recipe(self):
+        """Test a complex multi-step recipe."""
+        result = bake(b"secret message", [
+            "To Base64",
+            "ROT13",
+            {"op": "XOR", "args": {"Key": {"string": "key", "option": "UTF8"}}},
+            "To Hex"
+        ])
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+
+# =============================================================================
+# CRYPTOGRAPHIC OPERATIONS (Modern)
+# =============================================================================
+
+class TestModernCrypto:
+    """Test modern cryptographic operations."""
+
+    def test_aes_encrypt_decrypt(self):
+        """Test AES encryption/decryption roundtrip."""
+        key = "0123456789abcdef"  # 16 bytes = AES-128
+        iv = "abcdef0123456789"
+
+        encrypted = bake(b"hello world", [{
+            "op": "AES Encrypt",
+            "args": {
+                "Key": {"string": key, "option": "UTF8"},
+                "IV": {"string": iv, "option": "UTF8"},
+                "Mode": "CBC",
+                "Input": "Raw",
+                "Output": "Hex"
+            }
+        }])
+
+        decrypted = bake(encrypted, [{
+            "op": "AES Decrypt",
+            "args": {
+                "Key": {"string": key, "option": "UTF8"},
+                "IV": {"string": iv, "option": "UTF8"},
+                "Mode": "CBC",
+                "Input": "Hex",
+                "Output": "Raw"
+            }
+        }])
+
+        assert b"hello world" in decrypted or decrypted == b"hello world"
+
+    def test_rc4_encrypt_decrypt(self):
+        """Test RC4 encryption/decryption roundtrip."""
+        result = bake(b"hello", [{
+            "op": "RC4",
+            "args": {"Passphrase": {"string": "secret", "option": "UTF8"}}
+        }])
+
+        decrypted = bake(result, [{
+            "op": "RC4",
+            "args": {"Passphrase": {"string": "secret", "option": "UTF8"}}
+        }])
+
+        assert decrypted == b"hello"
+
+    def test_blowfish_encrypt_decrypt(self):
+        """Test Blowfish encryption."""
+        key = "secretkey1234567"
+        iv = "12345678"
+
+        encrypted = bake(b"hello", [{
+            "op": "Blowfish Encrypt",
+            "args": {
+                "Key": {"string": key, "option": "UTF8"},
+                "IV": {"string": iv, "option": "UTF8"},
+                "Mode": "CBC",
+                "Input": "Raw",
+                "Output": "Hex"
+            }
+        }])
+
+        assert len(encrypted) > 0
+
+
+class TestRegex:
+    """Test regex operations."""
+
+    def test_regular_expression_extract(self):
+        result = bake("test123abc456", [{
+            "op": "Regular expression",
+            "args": {"Regex": "\\d+", "Output format": "List matches"}
+        }])
+        assert "123" in result or "456" in result
+
+
+class TestConversionOps:
+    """Test conversion operations that work."""
+
+    def test_convert_data_units(self):
+        result = bake("1024", [{"op": "Convert data units", "args": {"Input units": "Bytes", "Output units": "Kilobytes"}}])
+        assert "1" in result
+
+
+# =============================================================================
+# ANALYSIS OPERATIONS
+# =============================================================================
+
+class TestAnalysis:
+    """Test analysis operations."""
+
+    def test_analyse_hash(self):
+        result = bake("5d41402abc4b2a76b9719d911017c592", ["Analyse hash"])
+        assert "MD5" in result or "hash" in result.lower()
+
+
+# =============================================================================
+# ADDITIONAL ENCODING TESTS
+# =============================================================================
+
+class TestMoreEncodings:
+    """Additional encoding tests."""
+
+    def test_to_hexdump(self):
+        result = bake(b"hello", ["To Hexdump"])
+        assert "68" in result  # 'h' = 0x68
+
+    def test_from_hexdump(self):
+        hexdump_input = "00000000  68 65 6c 6c 6f                                    |hello|"
+        result = bake(hexdump_input, ["From Hexdump"])
+        assert result == b"hello"
+
+    def test_to_messagepack(self):
+        result = bake('{"test": 123}', ["To MessagePack"])
+        assert isinstance(result, bytes)
+
+    def test_swap_endianness(self):
+        result = bake("12345678", [{"op": "Swap endianness", "args": {"Word length": 4}}])
+        assert "78563412" in result

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,129 @@
+"""Tests for the JavaScript runtime abstraction layer."""
+
+import pytest
+
+from ida_cyberchef.runtime import (
+    JSRuntime,
+    get_available_runtimes,
+    get_runtime,
+    RuntimeNotAvailableError,
+)
+from ida_cyberchef.cyberchef import bake, get_chef, set_runtime, load_cyberchef
+
+
+class TestRuntimeDiscovery:
+    """Test runtime discovery and selection."""
+
+    def test_get_available_runtimes(self):
+        """At least one runtime should be available."""
+        available = get_available_runtimes()
+        assert len(available) > 0
+        assert "quickjs" in available  # QuickJS is always our fallback
+
+    def test_get_runtime_returns_jsruntime(self):
+        """get_runtime should return a JSRuntime instance."""
+        runtime = get_runtime()
+        assert isinstance(runtime, JSRuntime)
+
+    def test_get_runtime_quickjs(self):
+        """Explicitly request QuickJS runtime."""
+        runtime = get_runtime("quickjs")
+        assert runtime.name == "QuickJS"
+
+    def test_get_runtime_invalid(self):
+        """Invalid runtime name should raise ValueError."""
+        with pytest.raises(ValueError, match="Unknown runtime"):
+            get_runtime("nonexistent")
+
+
+class TestRuntimeInterface:
+    """Test runtime interface compliance."""
+
+    def test_runtime_has_name(self):
+        """Runtime should have a name property."""
+        runtime = get_runtime()
+        assert isinstance(runtime.name, str)
+        assert len(runtime.name) > 0
+
+    def test_runtime_needs_compression_fallback(self):
+        """Runtime should report compression fallback requirement."""
+        runtime = get_runtime()
+        assert isinstance(runtime.needs_compression_fallback, bool)
+
+    def test_quickjs_needs_compression_fallback(self):
+        """QuickJS should need compression fallback."""
+        runtime = get_runtime("quickjs")
+        assert runtime.needs_compression_fallback is True
+
+
+class TestRuntimeExecution:
+    """Test runtime execution capabilities."""
+
+    def test_load_cyberchef(self):
+        """Test loading CyberChef into runtime."""
+        runtime = load_cyberchef()
+        assert runtime is not None
+        assert isinstance(runtime, JSRuntime)
+
+    def test_bake_basic(self):
+        """Test basic bake operation through runtime."""
+        result = bake("hello", ["To Base64"])
+        assert result == "aGVsbG8="
+
+    def test_bake_bytes_input(self):
+        """Test bake with bytes input."""
+        result = bake(b"hello", ["To Hex"])
+        assert "68 65 6c 6c 6f" in result
+
+    def test_bake_chain(self):
+        """Test chained operations."""
+        result = bake("hello", ["To Base64", "From Base64"])
+        assert result == b"hello"
+
+    def test_set_runtime(self):
+        """Test setting custom runtime."""
+        # Clear runtime
+        set_runtime(None)
+
+        # Get fresh runtime
+        runtime = get_chef()
+        assert runtime is not None
+
+        # Reset
+        set_runtime(None)
+
+
+class TestRuntimeCompression:
+    """Test compression with runtime fallbacks."""
+
+    def test_compression_with_quickjs(self):
+        """Compression should work via Python fallback with QuickJS."""
+        set_runtime(None)  # Clear cached runtime
+
+        # Force QuickJS
+        runtime = load_cyberchef(preferred_runtime="quickjs")
+        set_runtime(runtime)
+
+        try:
+            # This uses Python fallback
+            result = bake(b"hello world", ["Gzip", "Gunzip"])
+            assert result == b"hello world"
+        finally:
+            set_runtime(None)
+
+    def test_mixed_js_and_python_ops(self):
+        """Mixed JS and Python operations should work."""
+        result = bake(b"hello", ["To Base64", "Gzip", "Gunzip", "From Base64"])
+        assert result == b"hello"
+
+
+class TestRuntimeProperties:
+    """Test runtime-specific properties."""
+
+    def test_quickjs_properties(self):
+        """Test QuickJS-specific properties."""
+        from ida_cyberchef.runtime.quickjs_runtime import QuickJSRuntime
+
+        runtime = QuickJSRuntime()
+        assert runtime.name == "QuickJS"
+        assert runtime.needs_compression_fallback is True


### PR DESCRIPTION
This commit replaces STPyV8 (V8 bindings) with QuickJS for executing
CyberChef JavaScript operations. Key changes:

- Replace stpyv8>=13.1.201.22 with quickjs>=1.19.2 in dependencies
- Rewrite cyberchef.py to use QuickJS Context API
- Update __init__.py to make Qt imports optional (headless support)
- Update tests to use bake() API consistently
- Add comprehensive test suite (test_operations_comprehensive.py)

Benefits of QuickJS over STPyV8:
- Smaller footprint (~300KB vs V8's multi-MB)
- Easier to install (pure wheel, no system dependencies)
- Same ES2023 JavaScript support
- Memory and time limits available

Test results: 132 passed, 5 failed (96.4% pass rate)

Working operation categories:
- Base encodings (Base64, Base32, Base58, Base62, Base85)
- Hex encodings (To/From Hex, Hexdump)
- Character encodings (Binary, Octal, Decimal, Charcode)
- URL/HTML encodings
- All hash operations (MD2/4/5, SHA1/2/3, BLAKE2, RIPEMD, CRC, HMAC)
- String manipulation (Reverse, Case, Split, Sort, Unique, etc.)
- Arithmetic/Logic (XOR, AND, OR, NOT, ADD, SUB, bit shifts, rotates)
- JSON/XML operations
- Classical ciphers (ROT13/47, Atbash, Vigenère, Affine, A1Z26)
- Network parsing (IP, URL, URI)
- Data extraction (URLs, emails, IPs, dates, file paths)
- Morse code, Braille
- Modern crypto (Blowfish, some AES)
- Regex operations