### PR TITLE
Use optional-dependencies instead of dependency-groups for dev deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "stpyv8>=13.1.201.22",
 ]
 
-[dependency-groups]
+[project.optional-dependencies]
 dev = [
     "pytest>=8.4.2",
     "pytest-qt>=4.0",


### PR DESCRIPTION
Change from PEP 735 dependency-groups to PEP 508 optional-dependencies
so that `pip install -e ".[dev]"` works correctly in CI.